### PR TITLE
Adding more robust checks for registration. Removing added repo files.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  log_level: info
 
 platforms:
   - name: ubuntu-12.04
@@ -36,7 +37,7 @@ suites:
         enable_rhncfg: true
         rhncfg:
           actions:
-            run: true    
+            run: true
   - name: ubuntu14
     excludes:
       - centos-6
@@ -70,7 +71,7 @@ suites:
         enable_rhncfg: true
         rhncfg:
           actions:
-            run: true                        
+            run: true
   - name: centos7
     excludes:
       - centos-6
@@ -101,7 +102,9 @@ suites:
         reg:
           key: "1-centos6"
           server: "http://spacewalk.lan"
+          save: true
+        dont_add_repo_files: true
         enable_rhncfg: true
         rhncfg:
           actions:
-            run: true                    
+            run: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,3 +6,6 @@ default['spacewalk']['enable_rhncfg'] = false
 default['spacewalk']['reg']['key'] = 'my-reg-key'
 default['spacewalk']['reg']['server'] = 'http://spacewalk.example.com'
 default['spacewalk']['rhncfg']['actions']['run'] = false
+default['spacewalk']['reg']['save'] = false
+default['spacewalk']['reg']['key_dir'] = '/root/.spacewalk'
+default['spacewalk']['dont_add_repo_files'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'schuler.philipp@gmail.com'
 license          'GNU GPL v2'
 description      'Installs/Configures a Spacewalk client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.2.2'
 
 %w(ubuntu redhat centos).each do |os|
   supports os

--- a/recipes/rhel.rb
+++ b/recipes/rhel.rb
@@ -1,6 +1,65 @@
 arch = node['kernel']['machine'] == 'x86_64' ? 'x86_64' : 'i386'
 platform_major = node['platform_version'][0]
 
+do_register = false
+
+# check if up2date file has correct serverURL value
+up2date = '/etc/sysconfig/rhn/up2date'
+serverurl_value = "serverURL=#{node['spacewalk']['reg']['server']}/XMLRPC"
+if File.exist?(up2date)
+  unless IO.read(up2date).include?(serverurl_value)
+    Chef::Log.info('Wrong serverURL in up2date file, registering.')
+    do_register = true
+  end
+end
+
+# check if systemid file exists
+systemid = '/etc/sysconfig/rhn/systemid'
+unless File.exist?(systemid)
+  Chef::Log.info('Missing systemid file, registering.')
+  do_register = true
+end
+
+# if saving key
+key_dir = node['spacewalk']['reg']['key_dir']
+key_file = "#{key_dir}/key"
+if node['spacewalk']['reg']['save']
+  directory key_dir do
+    recursive true
+    owner 'root'
+    group 'root'
+    mode '600'
+    not_if { File.directory? key_dir }
+  end
+  if !do_register && File.exist?(key_file) && node['spacewalk']['reg']['key'] == IO.read(key_file)
+    Chef::Log.info("System has already been registered.")
+    return
+  end
+  file key_file do
+    content node['spacewalk']['reg']['key']
+    owner 'root'
+    group 'root'
+    mode '600'
+    action :create
+  end
+  unless do_register
+    Chef::Log.info("Missing reg_file or incorrect key_value in reg_file, registering.")
+    do_register = true
+  end
+end
+
+# Keep inventory of existing repos
+etc_yum_repos_d = '/etc/yum.repos.d'
+original_repos = []
+ruby_block 'remove_repo_files' do
+  block do
+    Dir.foreach(etc_yum_repos_d) do |repo|
+      next if repo == '.' or repo == '..'
+      original_repos << repo
+    end
+  end
+end
+
 remote_file "#{Chef::Config[:file_cache_path]}/spacewalk-client-repo.rpm" do
   source "#{node['spacewalk']['rhel']['base_url']}/#{platform_major}/#{arch}/spacewalk-client-repo-#{node['spacewalk']['rhel']['repo_version']}.el#{platform_major}.noarch.rpm"
   action :create
@@ -55,9 +114,9 @@ if node['spacewalk']['enable_osad']
   end
 
   execute 'register-with-spacewalk-server' do
-    command "rhnreg_ks --activationkey=#{node['spacewalk']['reg']['key']} --serverUrl=#{node['spacewalk']['reg']['server']}/XMLRPC"
-    not_if { (File.exist?('/etc/sysconfig/rhn/systemid')) }
+    command "rhnreg_ks --activationkey=#{node['spacewalk']['reg']['key']} --serverUrl=#{node['spacewalk']['reg']['server']}/XMLRPC --force"
     notifies :restart, 'service[osad]'
+    only_if { do_register }
   end
 
   service 'osad' do
@@ -66,7 +125,22 @@ if node['spacewalk']['enable_osad']
   end
 else
   execute 'register-with-spacewalk-server' do
-    command "rhnreg_ks --activationkey=#{node['spacewalk']['reg']['key']} --serverUrl=#{node['spacewalk']['reg']['server']}/XMLRPC"
-    not_if { (File.exist?('/etc/sysconfig/rhn/systemid')) }
+    command "rhnreg_ks --activationkey=#{node['spacewalk']['reg']['key']} --serverUrl=#{node['spacewalk']['reg']['server']}/XMLRPC --force"
+    only_if { do_register }
+  end
+end
+
+# remove repos that were added by this recipe
+if node['spacewalk']['dont_add_repo_files']
+  ruby_block 'remove_repo_files' do
+    block do
+      Dir.foreach(etc_yum_repos_d) do |repo|
+        next if repo == '.' or repo == '..'
+        if !original_repos.include? repo
+          Chef::Log.info("Removing repo file: #{repo}")
+          File.delete("#{etc_yum_repos_d}/#{repo}")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
A more robust way of checking whether or not to re-register a system has been implemented. Several checks are now in place, which should all trigger re-registration.

- Checking if up2date file has the correct serverURL value.
- Checking if systemid file exists. (the old check)
- A new ability to save the key (default /home/.spacewalk/key). This will allow next chef-client run to check key vs previous key. If they are different, trigger a re-register.

Removing added repo files:

- Old recipe would leave behind repo files. This could be undesirable. So a new attribute 'dont_add_repo_files' (elegantly named) was added. This will delete any added repo files if set to true.

☆彡☆ミ